### PR TITLE
Ignore socket stats

### DIFF
--- a/check_haproxy_stats.pl
+++ b/check_haproxy_stats.pl
@@ -232,6 +232,7 @@ while (<$haproxy>) {
         if ($data[$status] ne 'UP') {
             next if ($ignore_maint && $data[$status] eq 'MAINT');
             next if $data[$status] eq 'no check';   # Ignore server if no check is configured to be run
+            next if $data[$svname] eq 'sock-1';
             $exitcode = 2;
             our $check_status;
             $msg .= sprintf "server: %s:%s is %s", $data[$pxname], $data[$svname], $data[$status];


### PR DESCRIPTION
When using 'option socket-stats' in haproxy.cfg, there
are additional lines printed in the socket stats output.

These additional entries were causing issues.  I've added code
to ignore those additional entries. Though, it may not be a bad
idea to actually parse them later on.
