### PR TITLE
Remove perl 5 10 requirement

### DIFF
--- a/check_haproxy_stats.pl
+++ b/check_haproxy_stats.pl
@@ -15,7 +15,7 @@
 # warranty of merchantability or fitness for a particular purpose.
 #
 
-our $VERSION = "1.1.0";
+our $VERSION = "1.1.1";
 
 open(STDERR, ">&STDOUT");
 
@@ -27,6 +27,7 @@ open(STDERR, ">&STDOUT");
 #   1.0.4   - fix undef vars
 #   1.0.5   - fix thresholds
 #   1.1.0   - support for HTTP interface
+#   1.1.1   - drop perl 5.10 requirement
 
 use strict;
 use warnings;

--- a/check_haproxy_stats.pl
+++ b/check_haproxy_stats.pl
@@ -1,13 +1,13 @@
-#!/usr/bin/env perl 
+#!/usr/bin/env perl
 # vim: se et ts=4:
 
 #
 # Copyright (C) 2012, Giacomo Montagner <giacomo@entirelyunlike.net>
-# 
-# This program is free software; you can redistribute it and/or modify it 
-# under the same terms as Perl 5.10.1. 
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the same terms as Perl 5.10.1.
 # For more details, see http://dev.perl.org/licenses/artistic.html
-# 
+#
 # This program is distributed in the hope that it will be
 # useful, but without any warranty; without even the implied
 # warranty of merchantability or fitness for a particular purpose.
@@ -85,17 +85,17 @@ DESCRIPTION
         Set warning threshold for sessions number to the specified percentage (see -c)
 
 CHECKS AND OUTPUT
-    $me checks every proxy (or the named ones, if -p was given) 
-    for status. It returns an error if any of the checked FRONTENDs is not OPEN, 
+    $me checks every proxy (or the named ones, if -p was given)
+    for status. It returns an error if any of the checked FRONTENDs is not OPEN,
     any of the checked BACKENDs is not UP, or any of the checkes servers is not UP;
-    $me reports any problem it found. 
+    $me reports any problem it found.
 
 EXAMPLES
     $me -s /var/spool/haproxy/sock
         Use /var/spool/haproxy/sock to communicate with haproxy.
 
     $me -p proxy1,proxy2 -w 60 -c 80
-        Check only proxies named "proxy1" and "proxy2", and set sessions number 
+        Check only proxies named "proxy1" and "proxy2", and set sessions number
         thresholds to 60% and 80%.
 
 AUTHOR
@@ -105,12 +105,12 @@ REPORTING BUGS
     Please report any bug to bugs\@entirelyunlike.net
 
 COPYRIGHT
-    Copyright (C) 2012 Giacomo Montagner <giacomo\@entirelyunlike.net>. 
+    Copyright (C) 2012 Giacomo Montagner <giacomo\@entirelyunlike.net>.
     $me is distributed under GPL and the Artistic License 2.0
 
 SEE ALSO
     Check out online haproxy documentation at <http://haproxy.1wt.eu/>
-    
+
 EOU
 }
 
@@ -203,9 +203,9 @@ my @hastats = ( split /\n/, $haproxy );
 my $labels = $hastats[0];
 die "Unable to retrieve haproxy stats" unless $labels;
 chomp($labels);
-$labels =~ s/^# // or die "Data format not supported."; 
+$labels =~ s/^# // or die "Data format not supported.";
 my @labels = split /,/, $labels;
-{ 
+{
     no strict "refs";
     my $idx = 0;
     map { $$_ = $idx++ } @labels;
@@ -237,14 +237,14 @@ foreach (@hastats) {
     if (@proxies) { next unless grep {$data[$pxname] eq $_} @proxies; };
     if (@no_proxies) { next if grep {$data[$pxname] eq $_} @no_proxies; };
 
-    # Is session limit enforced? 
+    # Is session limit enforced?
     if ($data[$slim]) {
         $perfdata .= sprintf "%s-%s=%u;%u;%u;0;%u;", $data[$pxname], $data[$svname], $data[$scur], $swarn * $data[$slim] / 100, $scrit * $data[$slim] / 100, $data[$slim];
 
         # Check current session # against limit
         my $sratio = $data[$scur]/$data[$slim];
         if ($sratio >= $scrit / 100 || $sratio >= $swarn / 100) {
-            $exitcode = $sratio >= $scrit / 100 ? 2 : 
+            $exitcode = $sratio >= $scrit / 100 ? 2 :
                 $exitcode < 2 ? 1 : $exitcode;
             $msg .= sprintf "%s:%s sessions: %.2f%%; ", $data[$pxname], $data[$svname], $sratio * 100;
         }

--- a/check_haproxy_stats.pl
+++ b/check_haproxy_stats.pl
@@ -30,7 +30,6 @@ open(STDERR, ">&STDOUT");
 
 use strict;
 use warnings;
-use 5.010.001;
 use File::Basename qw/basename/;
 use IO::Socket::UNIX;
 use Getopt::Long;
@@ -243,7 +242,9 @@ my $perfdata = "";
 
 # Remove excluded proxies from the list if both -p and -P options are
 # specified.
-@proxies = grep{ not $_ ~~ @no_proxies } @proxies;
+my %hash;
+@hash{@no_proxies} = undef;
+@proxies = grep{ not exists $hash{$_} } @proxies;
 
 foreach (@hastats) {
     chomp;
@@ -297,6 +298,6 @@ foreach (@hastats) {
 unless ($msg) {
     $msg = @proxies ? sprintf("checked proxies: %s", join ', ', sort @proxies) : "checked $checked proxies.";
 }
-say "Check haproxy $status_names[$exitcode] - $msg|$perfdata";
+print "Check haproxy $status_names[$exitcode] - $msg|$perfdata\n";
 exit $exitcode;
 

--- a/check_haproxy_stats.pl
+++ b/check_haproxy_stats.pl
@@ -77,10 +77,10 @@ DESCRIPTION
     -U, --url
         Use HTTP URL instead of socket
 
-    -u, --username
+    -u, --user, --username
         Username for the HTTP URL
 
-    -x, --password
+    -x, --pass, --password
         Password for the HTTP URL
 
     -w, --warning

--- a/check_haproxy_stats.pl
+++ b/check_haproxy_stats.pl
@@ -3,6 +3,8 @@
 
 #
 # Copyright (C) 2012, Giacomo Montagner <giacomo@entirelyunlike.net>
+#               2015, Yann Fertat, Romain Dessort, Jeff Palmer,
+#                     Christophe Drevet-Droguet <dr4ke@dr4ke.net>
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl 5.10.1.
@@ -13,7 +15,7 @@
 # warranty of merchantability or fitness for a particular purpose.
 #
 
-our $VERSION = "1.0.5";
+our $VERSION = "1.1.0";
 
 open(STDERR, ">&STDOUT");
 


### PR DESCRIPTION
On top of my `stats_url_simple` branch, removes the perl 5.10 requirement.
